### PR TITLE
README - replaces Levenshtein with python-levenshtein

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Thanks little buddy.
 Nonstandard python libraries:
 * xmltodict
 * ffmpy
-* Levenshtein
+* python-levenshtein
 * lxml
 
 DB modules dependencies: 


### PR DESCRIPTION
Even though the module name is `Levenshtein`, in order to install the package via `pip`, you must declare `python-levenshtein`, and this seems to be the name of this python implementation. This might save some time for others when installing the correct dependencies.