### PR TITLE
ingestSip - makes inputPath and operator args mandatory, should fix #16 and #17

### DIFF
--- a/ingestSip.py
+++ b/ingestSip.py
@@ -38,11 +38,13 @@ def set_args():
 	parser = argparse.ArgumentParser()
 	parser.add_argument(
 		'-i','--inputPath',
-		help='path of input file'
+		help='path of input file',
+		required=True
 		)
 	parser.add_argument(
 		'-u','--operator',
-		help='name of the person doing the ingest'
+		help='name of the person doing the ingest',
+		required=True
 		)
 	parser.add_argument(
 		'-j','--metadataJSON',


### PR DESCRIPTION
I just edited these in the web editor, hopefully it hasn't introduced spaces rather than tabs. I haven't tested this but it should work.