### PR TITLE
Audio handling

### DIFF
--- a/ingestClasses.py
+++ b/ingestClasses.py
@@ -34,6 +34,8 @@ class ProcessArguments:
 		overrideOutdir=None,
 		overrideAIPdir=None,
 		overrideRS=None,
+		mono=None,
+		combineAudio=None
 		):
 		#######
 		# GLOBAL CONFIG (this is ConfigParser object, callable as a dict)
@@ -49,6 +51,8 @@ class ProcessArguments:
 		self.makeProres = makeProres
 		self.concatChoice = concatChoice
 		self.cleanupStrategy = cleanupStrategy
+		self.mono = mono
+		self.combineAudio = combineAudio
 
 		if None in (overrideOutdir,overrideAIPdir,overrideRS):
 			# if any of the outdirs is empty check for config settings

--- a/ingestSip.py
+++ b/ingestSip.py
@@ -7,8 +7,6 @@ creates fixity checks,
 and packages the whole lot in an OAIS-like Archival Information Package
 
 @fixme = stuff to do
-@logme = stuff to add to ingest log
-@dbme = stuff to add to PREMIS db
 '''
 # standard library modules
 import argparse
@@ -111,6 +109,14 @@ def set_args():
 			'enter a full directory path to override path set in config; '
 			'sets output directory for ingestSip.py'
 			)
+		)
+	parser.add_argument(
+		'-m','--mono_access_copy',
+		help='select to mixdown access copy audio to single mono stream'
+		)
+	parser.add_argument(
+		'-k','--combine_audio_streams',
+		help='select to mixdown access copy audio to single stereo stream'
 		)
 
 	return parser.parse_args()
@@ -504,6 +510,8 @@ def make_derivs(CurrentIngest,rsPackage=None,isSequence=None):
 	makeProres = CurrentIngest.ProcessArguments.makeProres
 	ingestType = CurrentIngest.ProcessArguments.ingestType
 	resourcespace_deliver = CurrentIngest.ProcessArguments.resourcespace_deliver
+	mono = CurrentIngest.ProcessArguments.mono
+	combineAudio = CurrentIngest.ProcessArguments.combineAudio
 
 	# make an enclosing folder for access copies if the input is a
 	# group of related video files
@@ -545,6 +553,12 @@ def make_derivs(CurrentIngest,rsPackage=None,isSequence=None):
 			sysargs.append('-r'+rsPackageDelivery)
 		if isSequence:
 			sysargs.append('-s')
+		if mono:
+			# select to mixdown audio to mono
+			sysargs.append('-m')
+		if combineAudio:
+			# select to mix all audio tracks to one stereo track
+			sysargs.append('-k')
 		sys.argv = 	sysargs
 		
 		deliveredDeriv = makeDerivs.main()
@@ -907,6 +921,8 @@ def main():
 	overrideOutdir = args.outdir_ingestsip
 	overrideAIPdir = args.aip_staging
 	overrideRS = args.resourcespace_deliver
+	mono = args.mono_access_copy
+	combineAudio = args.combine_audio_streams
 
 	# init some objects
 	CurrentProcess = ingestClasses.ProcessArguments(
@@ -919,7 +935,9 @@ def main():
 		cleanupStrategy,
 		overrideOutdir,
 		overrideAIPdir,
-		overrideRS
+		overrideRS,
+		mono,
+		combineAudio
 		)
 	CurrentObject = ingestClasses.InputObject(inputPath)
 	CurrentIngest = ingestClasses.Ingest(CurrentProcess,CurrentObject)
@@ -972,7 +990,6 @@ def main():
 
 	# tell the various logs that we are starting
 	CurrentIngest.caller = 'ingestSIP.main()'
-	# CurrentIngest.currentTargetObject = CurrentIngest.InputObject.canonicalName
 	loggers.log_event(
 		CurrentIngest,
 		event = 'ingestion start',
@@ -1122,7 +1139,8 @@ def main():
 					CurrentIngest,
 					_object.objectCategoryDetail
 					)
-				# note: this logs status = OK whether or not it is actually ok.
+				# note: 
+				# this logs status = OK whether or not it is actually ok. @fixme
 				loggers.pymm_log(
 					CurrentIngest,
 					event = 'metadata extraction',

--- a/makeDerivs.py
+++ b/makeDerivs.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-# YOU WANT TO MAKE SOME DERIVATIVES, PUNK?
+'''
+This script takes an input AV object and outputs an access copy. 
+It is relatively tailored to use within BAMPFA's EDITH app, 
+but mostly in terms of the output folder structure (it expects you to
+want a folder called 'resourcespace'). The transcoding options are 
+set in dicts in `pymmconfig`. You can also leave the dicts empty and
+use the defaults below for testing.
+I haven't (4/2019) put much thought into ProRes output, but that 
+may or may not become a necessity for us later. For now, we are outputting 
+H264 in mp4 for video and mp3 for audio input.
+'''
 import argparse
 import json
 import os
@@ -130,8 +140,8 @@ def set_middle_options(
 			# if the input has two mono tracks, check if one is "empty"
 			# and if so, discard it. Checks for RMS peak dB below -50
 			empty = pymmFunctions.check_empty_mono_track(inputPath)
-			print(empty)
-			print(type(empty))
+			# print(empty)
+			# print(type(empty))
 			if empty != None:
 				middleOptions['-filter_complex'] = \
 					"[0:a:{}]aformat=channel_layouts=stereo".format(str(empty))

--- a/makeDerivs.py
+++ b/makeDerivs.py
@@ -87,9 +87,13 @@ def set_middle_options(
 		# also used as our Proxy for access screenings
 		# list in config setting requires double quotes
 		if inputType in ('VIDEO','sequence'):
-			middleOptions = json.loads(config['ffmpeg']['resourcespace_video_opts'])
+			middleOptions = json.loads(
+				config['ffmpeg']['resourcespace_video_opts']
+				)
 		elif inputType == 'AUDIO':
-			middleOptions = json.loads(config['ffmpeg']['resourcespace_audio_opts'])
+			middleOptions = json.loads(
+				config['ffmpeg']['resourcespace_audio_opts']
+				)
 
 		# test/set a default proxy command for FFMPEG call
 		if middleOptions == {}:
@@ -122,6 +126,11 @@ def set_middle_options(
 				middleOptions['-map'] = '0:v -map 0:a'
 		else:
 			middleOptions['-map'] = '0:v -map 0:a'
+			if inputType == 'AUDIO':
+				# remove video stream map for audio input
+				middleOptions['-map'] = middleOptions['-map'].replace(
+					'0:v -map ',''
+					)
 
 	elif derivType == 'proresHQ':
 		# make a HQ prores .mov file as a mezzanine 
@@ -231,7 +240,7 @@ def add_audio_filter(middleOptions,inputPath):
 		
 		for stream in reversed(range(audioStreamCount)):
 			streamIndex = "[0:a:{}]".format(str(stream))
-			audioFilter = streamIndex+audioFilter
+			audioFilter = streamIndex+audioFilter # add each track in reverse order
 		# YOU DONT NEED To WRAP THE FILTER (OR ANYTHING ELSE?) IN QUOTES
 		# WHEN CALLING FROM SUBPROCESS
 		# audioFilter = '"{}"'.format(audioFilter) # wrap the filter in quotes
@@ -300,7 +309,7 @@ def set_args():
 		action='store_true',
 		help=(
 			"Do/don't map all existing audio streams "
-			"to access copy. "
+			"to access copy. Default is to keep all streams as-is. "
 			"Use this flag to mix to single (stereo) track."
 			"Set -m if you want mono instead."
 			)

--- a/makeDerivs.py
+++ b/makeDerivs.py
@@ -130,11 +130,13 @@ def set_middle_options(
 			# if the input has two mono tracks, check if one is "empty"
 			# and if so, discard it. Checks for RMS peak dB below -50
 			empty = pymmFunctions.check_empty_mono_track(inputPath)
+			print(empty)
+			print(type(empty))
 			if empty != None:
 				middleOptions['-filter_complex'] = \
-					"[0:a:{}]aformat=channel_layouts=stereo".format(empty)
-			elif empty == 'both':
-				# both mono tracks are empty??
+					"[0:a:{}]aformat=channel_layouts=stereo".format(str(empty))
+			else:
+				# what if both mono tracks are empty??
 				middleOptions['-map'] = '0:v -map 0:a'
 
 		else:

--- a/pymmFunctions.py
+++ b/pymmFunctions.py
@@ -696,6 +696,35 @@ def parse_sequence_folder(dpxPath):
 	# print(filePattern,startNumber,file0)
 	return filePattern,startNumber,file0
 
+def get_audio_stream_count(inputPath):
+	'''
+	Count the audio streams present in an av file. 
+	For a file with audio track(s) it should return one line per stream:
+		'streams.stream.0.index=1'
+	Tally these lines and take that as the count of audio streams. 
+	'''
+	probeCommand = [
+		'ffprobe', '-hide_banner',
+		inputPath,
+		'-select_streams', 'a',
+		'-show_entries', 'stream=index',
+		'-of', 'flat'
+		]
+	count = None
+	try:
+		count = 0
+		probe = subprocess.run(
+			probeCommand,
+			stdout=subprocess.PIPE, # this should return a list of streams
+			stderr=subprocess.PIPE
+			)
+		count += len(probe.stdout.splitlines())
+	except Exception as e:
+		print(e)
+		pass
+
+	return count
+
 #
 # END FILE CHECK STUFF 
 #

--- a/pymmFunctions.py
+++ b/pymmFunctions.py
@@ -793,22 +793,26 @@ def check_empty_mono_track(inputPath):
 			int(float(line.replace('RMS peak dB: ',''))) for line in chopped \
 				if line.startswith('RMS peak dB: ')
 			]
-		# print(peakdB)
+		print(peakdB)
 		try:
 			if peakdB[1] < -50:
 				empty[stream] = True
 		except:
 			pass
 
+	print(empty)
 	returnValue = None
 	count = 0
-	for k,v in empty.items():
-		if not v:
-			returnValue = k # return the stream id to keep
-		else:
-			count += 1
-	if count > 1:
-		returnValue = 'both'
+	if any([v for v in empty.values()]):		
+		for k,v in empty.items():
+			if not v:
+				returnValue = k # return the stream id to keep
+			else:
+				count += 1
+		if count > 1:
+			returnValue = 'both'
+	else:
+		returnValue = None
 
 	return returnValue
 

--- a/pymmFunctions.py
+++ b/pymmFunctions.py
@@ -793,14 +793,14 @@ def check_empty_mono_track(inputPath):
 			int(float(line.replace('RMS peak dB: ',''))) for line in chopped \
 				if line.startswith('RMS peak dB: ')
 			]
-		print(peakdB)
+		# print(peakdB)
 		try:
 			if peakdB[1] < -50:
 				empty[stream] = True
 		except:
 			pass
 
-	print(empty)
+	# print(empty)
 	returnValue = None
 	count = 0
 	if any([v for v in empty.values()]):		

--- a/pymmconfig/example_config.ini
+++ b/pymmconfig/example_config.ini
@@ -28,25 +28,23 @@ film_scan_mezzanine:
 low_res_proxy:				
 
 [ffmpeg]
-resourcespace_video_opts = [
-			"-movflags","faststart",
-			"-pix_fmt","yuv420p",
-			"-c:v","libx264",
-			"-bufsize","1835k",
-			"-f","mp4",
-			"-crf","18",
-			"-maxrate","8760k",
-			"-c:a","aac",
-			"-ac","2",
-			"-b:a","320k",
-			"-ar","48000"
-			]
+resourcespace_video_opts = {
+	"-movflags":"faststart",
+	"-threads":"12", # just being conservative with hardware
+	"-pix_fmt":"yuv420p",
+	"-c:v":"libx264",
+	"-f":"mp4",
+	"-crf":"23",
+	"-c:a":"aac",
+	"-b:a":"320k",
+	"-ar":"48000"
+	}
 proresHQ_opts = ["a","b","c"]
-resourcespace_audio_opts = [
-	"-id3v2_version","3",
-	"-dither_method","rectangular",
-	"-qscale:a","1"
-	]
+resourcespace_audio_opts = {
+	"-id3v2_version":"3",
+	"-dither_method":"rectangular",
+	"-qscale:a":"1"
+	}
 
 
 [bwf constants]

--- a/pymmconfig/pymmconfig.py
+++ b/pymmconfig/pymmconfig.py
@@ -22,7 +22,7 @@ def make_config(configPath):
 				\n\n[database users]\nuser: password\
 				\n\n[logging]\npymm_log_dir:\
 				\n\n[mediaconch format policies]\nfilm_scan_master:\nvideo_capture_master:\nmagnetic_video_mezzanine:\nfilm_scan_mezzanine:\nlow_res_proxy:\
-				\n\n[ffmpeg]\nresourcespace_video_opts:["a","b","c"]\nproresHQ_opts:["a","b","c"]\nresourcespace_audio_opts:["a","b","c"]
+				\n\n[ffmpeg]\nresourcespace_video_opts:{}\nproresHQ_opts:["a","b","c"]\nresourcespace_audio_opts:{}
 				\n\n[bwf constants]\noriginator:\ncoding_history_ANALOG:\
 				''')
 


### PR DESCRIPTION
This adds some more detail to handling audio input when making access files, for example, when multiple audio streams will need to be handled. 

I also added a test for an empty mono audio stream, which seems to be the case with a lot of U-matics transferred (by students?) with two discrete mono tracks, one of which may be empty. In these cases, I set the threshold @ -50dB RMS peak to indicate a functionally empty track.

The tests I've added borrow *heavily* from `mmfunctions`, thx @dericed.