### PR TITLE
Redo concat

### DIFF
--- a/concatFiles.py
+++ b/concatFiles.py
@@ -313,6 +313,7 @@ def main():
 		print(problems)
 		return problems,success
 	# safe_to_concat returns either True or a list of problems
+	safeToConcat = None
 	simpleConcat = safe_to_concat(sourceList)
 	complexConcat = None # placeholder
 
@@ -334,7 +335,7 @@ def main():
 				)
 		except:
 			problems += "\nsome problem with the concat process."
-			print(problems)
+			# print(problems)
 	else:
 
 		problems += simpleConcat
@@ -350,8 +351,19 @@ def main():
 		os.rename(concattedFile,newPath)
 		# reset the var to the new path name
 		concattedFile = newPath
-		success = True
-
+		if pymmFunctions.is_av(concattedFile) in ('VIDEO','AUDIO'):
+			success = True
+		else:
+			success = False
+			try:
+				os.remove(concattedFile)
+			except:
+				pass
+			problems += (
+				"\nOutput concat file is not recognized as AV!! "
+				"Something must have gone wrong. Sorry."
+				)
+			concattedFile = problems
 	else: 
 		success = False
 		concattedFile = problems

--- a/ingestClasses.py
+++ b/ingestClasses.py
@@ -369,7 +369,8 @@ class Ingest:
 		self.ingestResults = {
 			'status':False,
 			'abortReason':'',
-			'ingestUUID':self.ingestUUID
+			'ingestUUID':self.ingestUUID,
+			'notes':''
 			}
 		self.ingestLogPath = None
 

--- a/ingestSip.py
+++ b/ingestSip.py
@@ -126,7 +126,6 @@ def concat_access_files(CurrentIngest,wrapper):
 	sys.argv = [
 		'',
 		'-i'+inputPath,
-		'-d'+CurrentIngest.ingestUUID,
 		'-c'+CurrentIngest.InputObject.canonicalName,
 		'-w'+wrapper
 		]
@@ -167,6 +166,8 @@ def concat_access_files(CurrentIngest,wrapper):
 			"Here's the output of the attempt:\n{}\n"
 			"".format(concattedAccessFile)
 			)
+		CurrentIngest.ingestResults['notes'] += outcome
+		CurrentIngest.currentTargetObject = CurrentIngest
 	CurrentIngest.caller = CurrentIngest.ProcessArguments.ffmpegVersion
 	loggers.log_event(
 		CurrentIngest,

--- a/makeDerivs.py
+++ b/makeDerivs.py
@@ -255,7 +255,7 @@ def add_audio_merge_filter(middleOptions,inputPath):
 	'''
 	check for audio streams and add to a filter that will merge them all 
 	'''
-	audioStreamCount = pymmFunctions.get_audio_stream_count(inputPath)
+	audioStreamCount = pymmFunctions.get_stream_count(inputPath,"audio")
 	print(str(audioStreamCount)+' audio streams in '+inputPath)
 
 	if audioStreamCount in (None, 0, 1):

--- a/makeMetadata.py
+++ b/makeMetadata.py
@@ -80,23 +80,21 @@ def get_track_profiles(mediainfoDict):
 	Get audio and video track profiles to compare for concatenation of files.
 	Takes an OrderedDict as retrned by get_mediainfo_report.
 
-	Discard attributes that are not necessary but keep relevant attributes
-	that we want to compare between files. Prob can discard even more?
+	Define relevant attributes taken from MediaInfo
+	that we want to compare between files. Are these lists accurate? @fixme
 	'''
 	problems = 0
 	if isinstance(mediainfoDict,str):
 		mediainfoDict = ast.literal_eval(mediainfoDict)
-	videoAttribsToDiscard = [
-		'@type', 'ID', 'Format_Info', 'Format_profile',
-		'Format_settings__CABAC', 'Format_settings__ReFrames', 
-		'Format_settings__GOP', 'Codec_ID', 'Codec_ID_Info', 'Duration', 
-		'Scan_type', 'Bits__Pixel_Frame_', 'StreamSize', 'Language', 
-		'Tagged_date', 'Encoded_date', 'BitRate_Mode', 'BitRate', 
-		'FrameCount', 'BufferSize','Delay'
+
+	videoAttribsToKeep = [
+		'Format','Width','Height','PixelAspectRatio','DisplayAspectRatio',
+		'FrameRate','Standard','ColorSpace','ChromaSubsampling',
+		'BitDepth','ScanType','CodecID'
 		]
-	audioAttribsToDiscard = [
-		'@type', 'ID', 'Codec_ID', 'Duration', 'Stream_size', 
-		'Language', 'Encoded_date', 'Tagged_date'
+	
+	audioAttribsToKeep = [
+		'Format','CodecID','SamplingRate','SamplesPerFrame','BitDepth'
 		]
 	# `tracks` should be a list of track dicts
 	tracks = mediainfoDict['media']['track']
@@ -111,15 +109,29 @@ def get_track_profiles(mediainfoDict):
 			audioTrackProfile = track
 
 	if videoTrackProfile:
-		for attr in videoAttribsToDiscard:
-			videoTrackProfile.pop(attr,None)
+		# print(videoTrackProfile)
+		temp = {}
+		for attr in videoAttribsToKeep:
+			# videoTrackProfile.pop(attr,None)
+			if attr in videoTrackProfile:
+				temp[attr] = videoTrackProfile[attr]
+		videoTrackProfile = temp
+		del temp
+		# print(videoTrackProfile)
 	else:
 		problems += 1
 		print("mediainfo problem: "
 			"either there is no video track or you got some issues")
 	if audioTrackProfile:
-		for attr in audioAttribsToDiscard:
-			audioTrackProfile.pop(attr,None)
+		# print(audioTrackProfile)
+		temp = {}
+		for attr in audioAttribsToKeep:
+			if attr in audioTrackProfile:
+				temp[attr] = audioTrackProfile[attr]
+		audioTrackProfile = temp
+		del temp
+			# audioTrackProfile.pop(attr,None)
+		# print(audioTrackProfile)
 	else:
 		problems += 1
 		print("mediainfo problem: "

--- a/pymmFunctions.py
+++ b/pymmFunctions.py
@@ -770,7 +770,8 @@ def check_empty_mono_track(inputPath):
 	Intended usage is with a dual mono file so we can remove
 	an empty track and use the non-empty one as track 1.
 	
-	NB: setting "empty" as below -50dB peak, this could be tweaked
+	NB: setting "empty" as below -50dB RMS (root mean square) level,
+	  this could be tweaked!
 	'''
 	# ffmpeg -i /Users/michael/Desktop/test_files/illuminated_extract.mov -map 0:a:1 -af astats -f null -
 	empty = {0:False,1:False}
@@ -791,13 +792,13 @@ def check_empty_mono_track(inputPath):
 			)
 		stats = [line for line in output.stderr.decode().splitlines()]
 		chopped = [re.sub(r'\[Parsed_astats.+\]\ ','',line) for line in stats]
-		peakdB = [
+		leveldB = [
 			int(float(line.replace('RMS level dB: ',''))) for line in chopped \
 				if line.startswith('RMS level dB: ')
 			]
-		# print(peakdB)
+		# print(leveldB)
 		try:
-			if peakdB[1] < -50:
+			if leveldB[1] < -50:
 				empty[stream] = True
 		except:
 			pass

--- a/pymmFunctions.py
+++ b/pymmFunctions.py
@@ -792,8 +792,8 @@ def check_empty_mono_track(inputPath):
 		stats = [line for line in output.stderr.decode().splitlines()]
 		chopped = [re.sub(r'\[Parsed_astats.+\]\ ','',line) for line in stats]
 		peakdB = [
-			int(float(line.replace('RMS peak dB: ',''))) for line in chopped \
-				if line.startswith('RMS peak dB: ')
+			int(float(line.replace('RMS level dB: ',''))) for line in chopped \
+				if line.startswith('RMS level dB: ')
 			]
 		# print(peakdB)
 		try:

--- a/pymmFunctions.py
+++ b/pymmFunctions.py
@@ -696,17 +696,19 @@ def parse_sequence_folder(dpxPath):
 	# print(filePattern,startNumber,file0)
 	return filePattern,startNumber,file0
 
-def get_audio_stream_count(inputPath):
+def get_stream_count(inputPath,_type="video"):
 	'''
-	Count the audio streams present in an av file. 
-	For a file with audio track(s) it should return one line per stream:
+	Count the data streams present in an av file.
+	Specify _type as "audio" or "video" (default)
+	For example, a file with audio track(s) should return one line per stream:
 		'streams.stream.0.index=1'
 	Tally these lines and take that as the count of audio streams. 
 	'''
+
 	probeCommand = [
 		'ffprobe', '-hide_banner',
 		inputPath,
-		'-select_streams', 'a',
+		'-select_streams', _type[:1], # get the first letter of _type (a or v)
 		'-show_entries', 'stream=index',
 		'-of', 'flat'
 		]


### PR DESCRIPTION
This is mostly a more graceful handling of bad concatenation requests. 
* Adds a check for stream counts to concatenation
* Changes the check for empty mono tracks from "RMS peak" to "RMS level," which is the mean level of the selected track instead of the peak value (clicks and pops on an otherwise 'empty' track gave false positives)
* Gives more detail on why a concatenation was not attempted
* Simplifies the stats to check when comparing files for concat compatability
* Placeholders for more complex concatenations (to be added later? I don't have time now and there doesn't seem to be an immediate need) where files differ in encoding/etc.
